### PR TITLE
fix: old column row headers are not deleted before creating new ones

### DIFF
--- a/src/grid/grid.ts
+++ b/src/grid/grid.ts
@@ -656,8 +656,27 @@ export class Grid<TItem = any> implements EditorHost {
             }
         });
 
-
         this._layout.updateHeadersWidth();
+
+        const headerRowCols = this._layout.getHeaderRowCols();
+        headerRowCols.forEach(hrc => {
+            hrc.querySelectorAll(".slick-headerrow-column")
+                .forEach((el) => {
+                    var columnDef = this.getColumnFromNode(el);
+                    if (columnDef) {
+                        this.trigger(this.onBeforeHeaderRowCellDestroy, {
+                            node: el as HTMLElement,
+                            column: columnDef,
+                            grid: this
+                        });
+                    }
+                });
+            if (this._jQuery) {
+                this._jQuery(hrc).empty();
+            } else {
+                hrc.innerHTML = "";
+            }
+        }); 
 
         var cols = this._cols, frozenCols = this._layout.getFrozenCols();
         for (var i = 0; i < cols.length; i++) {


### PR DESCRIPTION
Old column row headers are not deleted, but created again, when for example the function setColumns() is called. The elements are appended on each call in the DOM.